### PR TITLE
Fix typo in MacOS detach impl

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -172,7 +172,7 @@ unsafe fn detach_command_handlers() {
     let _: () = msg_send!(cmd, setEnabled: NO);
     let _: () = msg_send!(cmd, removeTarget: nil);
 
-    let cmd: id = msg_send!(command_center, previousTrackComand);
+    let cmd: id = msg_send!(command_center, previousTrackCommand);
     let _: () = msg_send!(cmd, setEnabled: NO);
     let _: () = msg_send!(cmd, removeTarget: nil);
 


### PR DESCRIPTION
Fixes a little typo, casing the detach call to fail and lock up the host app.