### PR TITLE
mac: Add playback progress support

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -48,12 +48,15 @@ fn main() {
     };
 
     controls.attach(move |e| tx.send(e).unwrap()).unwrap();
-    controls.set_playback(MediaPlayback::Playing).unwrap();
+    controls
+        .set_playback(MediaPlayback::Playing { progress: None })
+        .unwrap();
     controls
         .set_metadata(MediaMetadata {
             title: Some("When The Sun Hits"),
             album: Some("Souvlaki"),
             artist: Some("Slowdive"),
+            duration: Some(Duration::from_secs_f64(4.0 * 60.0 + 50.0)),
             cover_url: Some("https://c.pxhere.com/photos/34/c1/souvlaki_authentic_greek_greek_food_mezes-497780.jpg!d"),
         })
         .unwrap();
@@ -86,9 +89,9 @@ fn main() {
                 if change {
                     controls
                         .set_playback(if app.playing {
-                            MediaPlayback::Playing
+                            MediaPlayback::Playing { progress: None }
                         } else {
-                            MediaPlayback::Paused
+                            MediaPlayback::Paused { progress: None }
                         })
                         .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 pub mod platform;
 
+use std::time::Duration;
+
 pub use platform::{Error, MediaControls};
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum MediaPlayback {
     Stopped,
-    Paused,
-    Playing,
+    Paused { progress: Option<Duration> },
+    Playing { progress: Option<Duration> },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
@@ -15,6 +17,7 @@ pub struct MediaMetadata<'a> {
     pub album: Option<&'a str>,
     pub artist: Option<&'a str>,
     pub cover_url: Option<&'a str>,
+    pub duration: Option<Duration>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -107,8 +107,8 @@ impl MediaControls {
 
     pub fn set_playback(&mut self, playback: MediaPlayback) -> Result<(), Error> {
         let status = match playback {
-            MediaPlayback::Playing => SmtcPlayback::Playing as i32,
-            MediaPlayback::Paused => SmtcPlayback::Paused as i32,
+            MediaPlayback::Playing { .. } => SmtcPlayback::Playing as i32,
+            MediaPlayback::Paused { .. } => SmtcPlayback::Paused as i32,
             MediaPlayback::Stopped => SmtcPlayback::Stopped as i32,
         };
         self.controls


### PR DESCRIPTION
Hi! This adds:

- `duration` field to `MediaMetadata`
- `progress` field to `Playing` and `Paused` playback variants
- support for these in the MacOS backend

Related to #10. What do you think?