### PR TITLE
Fix MediaControls return type for the empty platform

### DIFF
--- a/src/platform/empty/mod.rs
+++ b/src/platform/empty/mod.rs
@@ -10,7 +10,7 @@ pub struct MediaControls;
 impl MediaControls {
     /// Create media controls with the specified config.
     pub fn new(_config: PlatformConfig) -> Result<Self, Error> {
-        Self
+        Ok(Self)
     }
 
     /// Attach the media control events to a handler.


### PR DESCRIPTION
This unbreaks souvlaki on OpenBSD/amd64 7.0-current with rustc 1.56.1:
```
   |         expected enum `Result`, found struct `platform::platform::MediaControls`
   |         help: try using a variant of the expected enum: `Ok(Self)`
```

Found by building jpochyla/psst.
