### PR TITLE
use `xesam:artist` instead of `xesam:albumArtist`

### DIFF
--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -86,7 +86,7 @@ fn create_metadata_dict(metadata: &OwnedMetadata) -> HashMap<String, Variant<Box
         insert("xesam:title", Box::new(title.clone()));
     }
     if let Some(artist) = artist {
-        insert("xesam:albumArtist", Box::new(vec![artist.clone()]));
+        insert("xesam:artist", Box::new(vec![artist.clone()]));
     }
     if let Some(album) = album {
         insert("xesam:album", Box::new(album.clone()));


### PR DESCRIPTION
As noted in https://github.com/Sinono3/souvlaki/issues/21#issuecomment-1015691265, the GNOME mpris indicator displays "Unknown artist" instead of the artist's name, even though the `xesam:albumArtist` is provided.

This is due to the fact that most MPRIS indicators out there use `xesam:artist` ([GNOME](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/869560e05451cb3bef9bdf3bceba4e57543ef0b2/js/ui/mpris.js#L197-208), [KDE](https://invent.kde.org/plasma/plasma-workspace/-/blob/10b31ead111ab623879e7796f1434c15097b1f29/applets/mediacontroller/contents/ui/main.qml#L43-46)). With this patch applied, the track is showing correctly for me:

![souvlaki_mpris](https://user-images.githubusercontent.com/59307989/150836249-3270c4fc-78b9-4b8d-8d50-dd030b72b631.png)

PS: If you'd like to, you can either use this screenshot for the demonstration in the README (#17) or I can take another screenshot, if you rather like to have a different area displayed.