### PR TITLE
Consider updating Windows crate to 0.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 rust-version = "1.67"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
-version = "0.44"
+version = "0.52"
 features = [
 	"Foundation",
 	"Media",
@@ -44,7 +44,7 @@ winit = "0.27.0"
 raw-window-handle = "0.5.0"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies.windows]
-version = "0.44"
+version = "0.52"
 features = [
 	"Win32_Foundation",
 	"Win32_Graphics_Gdi",

--- a/examples/print_events.rs
+++ b/examples/print_events.rs
@@ -53,8 +53,7 @@ mod windows {
     use std::io::Error;
     use std::mem;
 
-    use windows::core::PCWSTR;
-    use windows::w;
+    use windows::core::{w, PCWSTR};
     use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
     use windows::Win32::System::LibraryLoader::GetModuleHandleW;
     use windows::Win32::UI::WindowsAndMessaging::{
@@ -77,7 +76,7 @@ mod windows {
 
                 let wnd_class = WNDCLASSEXW {
                     cbSize: mem::size_of::<WNDCLASSEXW>() as u32,
-                    hInstance: instance,
+                    hInstance: instance.into(),
                     lpszClassName: PCWSTR::from(class_name),
                     lpfnWndProc: Some(Self::wnd_proc),
                     ..Default::default()


### PR DESCRIPTION
On spotify_player we already have several versions of windows-* crates, among them 2 versions of the windows crate. I hope to reduce duplication for Souvlaki user by updating the crate.

I update and fix small compilation errors that are easily fixed. I do not have a Windows machine so I cannot do any validation on my side besides CI.

