### PR TITLE
Allow failing clippy lint

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::module_inception)]
 pub use self::platform::*;
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
Clippy throws a warning right now
