### PR TITLE
Add some error handling to zbus, and unify dbus/zbus Error type

### DIFF
--- a/src/platform/mpris/dbus/controls.rs
+++ b/src/platform/mpris/dbus/controls.rs
@@ -12,21 +12,7 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crate::{MediaControlEvent, MediaMetadata, MediaPlayback, PlatformConfig};
-
-/// A platform-specific error.
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error("internal D-Bus error: {0}")]
-    DbusError(#[from] dbus::Error),
-    #[error("D-bus service thread not running. Run MediaControls::attach()")]
-    ThreadNotRunning,
-    // NOTE: For now this error is not very descriptive. For now we can't do much about it
-    // since the panic message returned by JoinHandle::join does not implement Debug/Display,
-    // thus we cannot print it, though perhaps there is another way. I will leave this error here,
-    // to at least be able to catch it, but it is preferable to have this thread *not panic* at all.
-    #[error("D-Bus service thread panicked")]
-    ThreadPanicked,
-}
+use super::super::Error;
 
 /// A handle to OS media controls.
 pub struct MediaControls {

--- a/src/platform/mpris/dbus/mod.rs
+++ b/src/platform/mpris/dbus/mod.rs
@@ -1,4 +1,4 @@
 mod interfaces;
 
 mod controls;
-pub use controls::{Error, MediaControls};
+pub use controls::MediaControls;

--- a/src/platform/mpris/mod.rs
+++ b/src/platform/mpris/mod.rs
@@ -10,8 +10,31 @@ compile_error!("feature \"dbus\" and feature \"zbus\" are mutually exclusive");
 mod zbus;
 #[cfg(feature = "zbus")]
 pub use self::zbus::*;
+#[cfg(feature = "zbus")]
+extern crate zbus as zbus_crate;
 
 #[cfg(feature = "dbus")]
 mod dbus;
 #[cfg(feature = "dbus")]
 pub use self::dbus::*;
+#[cfg(feature = "dbus")]
+extern crate dbus as dbus_crate;
+
+/// A platform-specific error.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("internal D-Bus error: {0}")]
+    #[cfg(feature = "dbus")]
+    DbusError(#[from] dbus_crate::Error),
+    #[error("internal D-Bus error: {0}")]
+    #[cfg(feature = "zbus")]
+    DbusError(#[from] zbus_crate::Error),
+    #[error("D-bus service thread not running. Run MediaControls::attach()")]
+    ThreadNotRunning,
+    // NOTE: For now this error is not very descriptive. For now we can't do much about it
+    // since the panic message returned by JoinHandle::join does not implement Debug/Display,
+    // thus we cannot print it, though perhaps there is another way. I will leave this error here,
+    // to at least be able to catch it, but it is preferable to have this thread *not panic* at all.
+    #[error("D-Bus service thread panicked")]
+    ThreadPanicked,
+}

--- a/src/platform/mpris/zbus.rs
+++ b/src/platform/mpris/zbus.rs
@@ -14,8 +14,19 @@ use crate::{
 };
 
 /// A platform-specific error.
-#[derive(Debug)]
-pub struct Error;
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("internal D-Bus error: {0}")]
+    DbusError(#[from] zbus::Error),
+    #[error("D-bus service thread not running. Run MediaControls::attach()")]
+    ThreadNotRunning,
+    // NOTE: For now this error is not very descriptive. For now we can't do much about it
+    // since the panic message returned by JoinHandle::join does not implement Debug/Display,
+    // thus we cannot print it, though perhaps there is another way. I will leave this error here,
+    // to at least be able to catch it, but it is preferable to have this thread *not panic* at all.
+    #[error("D-Bus service thread panicked")]
+    ThreadPanicked,
+}
 
 /// A handle to OS media controls.
 pub struct MediaControls {
@@ -109,34 +120,34 @@ impl MediaControls {
             thread,
         }) = self.thread.take()
         {
-            event_channel.send(InternalEvent::Kill).unwrap();
-            thread.join().unwrap();
+            event_channel.send(InternalEvent::Kill).ok();
+            thread.join().map_err(|_| Error::ThreadPanicked)?;
         }
         Ok(())
     }
 
     /// Set the current playback status.
     pub fn set_playback(&mut self, playback: MediaPlayback) -> Result<(), Error> {
-        self.send_internal_event(InternalEvent::ChangePlayback(playback));
+        self.send_internal_event(InternalEvent::ChangePlayback(playback))?;
         Ok(())
     }
 
     /// Set the metadata of the currently playing media item.
     pub fn set_metadata(&mut self, metadata: MediaMetadata) -> Result<(), Error> {
-        self.send_internal_event(InternalEvent::ChangeMetadata(metadata.into()));
+        self.send_internal_event(InternalEvent::ChangeMetadata(metadata.into()))?;
         Ok(())
     }
 
     /// Set the volume level (0.0 - 1.0) (Only available on MPRIS)
     pub fn set_volume(&mut self, volume: f64) -> Result<(), Error> {
-        self.send_internal_event(InternalEvent::ChangeVolume(volume));
+        self.send_internal_event(InternalEvent::ChangeVolume(volume))?;
         Ok(())
     }
 
     // TODO: result
-    fn send_internal_event(&mut self, event: InternalEvent) {
+    fn send_internal_event(&mut self, event: InternalEvent) -> Result<(), Error> {
         let channel = &self.thread.as_ref().unwrap().event_channel;
-        channel.send(event).unwrap();
+        channel.send(event).map_err(|_| Error::ThreadPanicked)
     }
 }
 


### PR DESCRIPTION
The current implementation of zbus unwraps all errors, which could lead to crashes in cases where, for example, the D-Bus name is already taken by another program (possibly another instance). This PR ports error handling in dbus implementation to zbus, and moves `Error` in dbus to mpris/mod.rs as they share almost same logic.

Related: #32