### PR TITLE
Fix iOS import of std::fs

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -1,6 +1,9 @@
 #![cfg(any(target_os = "macos", target_os = "ios"))]
 #![allow(non_upper_case_globals)]
 
+#[cfg(target_os = "ios")]
+use std::fs;
+
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},


### PR DESCRIPTION
Otherwise a build for iOS fails with the following error:

```rust
error[E0433]: failed to resolve: use of undeclared crate or module `fs`
   --> /Users/willevans/.cargo/registry/src/index.crates.io-6f17d22bba15001f/souvlaki-0.8.1/src/platform/macos/mod.rs:293:22
    |
293 |     let image_data = fs::read(&url).unwrap();
    |                      ^^ use of undeclared crate or module `fs`
```