### PR TITLE
Improve iOS image setting as images can only be loaded locally

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub enum MediaControlEvent {
     /// But other values are also accepted. **It is up to the user to
     /// set constraints on this value.**
     /// **NOTE**: If the volume event was received and correctly handled,
-    /// the user must call [`MediaControls::set_volume`]. Note that 
+    /// the user must call [`MediaControls::set_volume`]. Note that
     /// this must be done only with the MPRIS backend.
     SetVolume(f64),
     /// Open the URI in the media player.

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -289,7 +289,7 @@ unsafe fn ns_url(value: &str) -> id {
 unsafe fn load_image_from_url(url: &str) -> (id, CGSize) {
     let url = ns_url(url);
     let ns_data: id = msg_send!(class!(NSData), alloc);
-    let ns_data: id = msg_send!(ns_data, dataWithContentsOfURL: url
+    let ns_data: id = msg_send!(ns_data, contentsOf: url
                                           options: 0);
     if ns_data == nil {
         return (nil, CGSize::new(0.0, 0.0));

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -287,10 +287,9 @@ unsafe fn ns_url(value: &str) -> id {
 
 #[cfg(target_os = "ios")]
 unsafe fn load_image_from_url(url: &str) -> (id, CGSize) {
-    let ns_url: id = msg_send!(class!(NSURL), URLWithString: url);
-
+    let url = ns_url(url);
     let ns_data: id = msg_send!(class!(NSData), alloc);
-    let ns_data: id = msg_send!(ns_data, dataWithContentsOfURL: ns_url
+    let ns_data: id = msg_send!(ns_data, dataWithContentsOfURL: url
                                           options: 0);
     if ns_data == nil {
         return (nil, CGSize::new(0.0, 0.0));

--- a/src/platform/mpris/dbus/controls.rs
+++ b/src/platform/mpris/dbus/controls.rs
@@ -11,8 +11,8 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use crate::{MediaControlEvent, MediaMetadata, MediaPlayback, PlatformConfig};
 use super::super::Error;
+use crate::{MediaControlEvent, MediaMetadata, MediaPlayback, PlatformConfig};
 
 /// A handle to OS media controls.
 pub struct MediaControls {

--- a/src/platform/mpris/zbus.rs
+++ b/src/platform/mpris/zbus.rs
@@ -132,7 +132,11 @@ impl MediaControls {
     }
 
     fn send_internal_event(&mut self, event: InternalEvent) -> Result<(), Error> {
-        let channel = &self.thread.as_ref().ok_or(Error::ThreadNotRunning)?.event_channel;
+        let channel = &self
+            .thread
+            .as_ref()
+            .ok_or(Error::ThreadNotRunning)?
+            .event_channel;
         channel.send(event).map_err(|_| Error::ThreadPanicked)
     }
 }

--- a/src/platform/windows/mod.rs
+++ b/src/platform/windows/mod.rs
@@ -184,7 +184,8 @@ impl MediaControls {
             let stream = if url.starts_with("file://") {
                 // url is a file, load it manually
                 let path = url.trim_start_matches("file://");
-                let loader = windows::Storage::StorageFile::GetFileFromPathAsync(&HSTRING::from(path))?;
+                let loader =
+                    windows::Storage::StorageFile::GetFileFromPathAsync(&HSTRING::from(path))?;
                 let results = loader.get()?;
                 loader.Close()?;
 


### PR DESCRIPTION
iOS does not support loading an image from HTTP, this ensures the file both exists (to avoid a panic) and is a file:// URL