### PR TITLE
Exclude dbus on Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ dispatch = "0.2.0"
 objc = "0.2.7"
 base64 = "0.22.1"
 
-[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))'.dependencies]
+[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "ios", target_os = "android"))))'.dependencies]
 dbus = { version = "0.9.5", optional = true }
 dbus-crossroads = { version = "0.5.0", optional = true }
 zbus = { version = "3.9", optional = true }


### PR DESCRIPTION
This allows cross-compilation on MacOS and as this dependency is currently unused on Android (thanks to https://github.com/Sinono3/souvlaki/issues/54) it is fine to exclude 