### PR TITLE
Add nil check for NSImage in macOS load_image_from_url

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -142,6 +142,9 @@ unsafe fn set_playback_metadata(metadata: MediaMetadata) {
 
 unsafe fn load_and_set_playback_artwork(url: String, for_counter: usize) {
     let (image, size) = load_image_from_url(&url);
+    if image == nil {
+        return;
+    }
     let artwork = mp_artwork(image, size);
     if GLOBAL_METADATA_COUNTER.load(Ordering::SeqCst) == for_counter {
         set_playback_artwork(artwork);
@@ -321,6 +324,9 @@ unsafe fn load_image_from_url(url: &str) -> (id, CGSize) {
     let url = ns_url(url);
     let image: id = msg_send!(class!(NSImage), alloc);
     let image: id = msg_send!(image, initWithContentsOfURL: url);
+    if image == nil {
+        return (nil, CGSize::new(0.0, 0.0));
+    }
     let size: CGSize = msg_send!(image, size);
     (image, CGSize::new(size.width, size.height))
 }


### PR DESCRIPTION
I was testing a dev version of the Music Assistant desktop app and ran into some nil-pointer issues. Tracked it down to this, where we had the iOS nil-check in place but not macOS.

The formal git commit message:

NSImage.initWithContentsOfURL: returns nil when the image cannot be loaded (network error, unreachable URL, invalid image data, etc.). The macOS implementation did not check for this, causing a null pointer dereference when calling .size on the nil image.

The iOS implementation already guards against this (lines 308-314). This adds the same nil checks to the macOS code path:
- In load_image_from_url: return (nil, CGSize(0,0)) if image is nil
- In load_and_set_playback_artwork: skip setting artwork if image is nil