### PR TITLE
Fix macOS build: stale Cocoa nil references from #76 merge

### DIFF
--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -149,7 +149,7 @@ unsafe fn set_playback_metadata(metadata: MediaMetadata) {
 unsafe fn load_and_set_playback_artwork(url: String, for_counter: usize) {
     unsafe {
         let (image, size) = load_image_from_url(&url);
-        if image == nil {
+        if image.is_null() {
             return;
         }
         let artwork = mp_artwork(image, size);
@@ -352,8 +352,8 @@ unsafe fn load_image_from_url(url: &str) -> (Id, CGSize) {
         let url = ns_url(url);
         let image: Id = msg_send!(class!(NSImage), alloc);
         let image: Id = msg_send!(image, initWithContentsOfURL: url);
-        if image == nil {
-            return (nil, CGSize::new(0.0, 0.0));
+        if image.is_null() {
+            return (std::ptr::null_mut(), CGSize::new(0.0, 0.0));
         }
         let size: CGSize = msg_send!(image, size);
         (image, CGSize::new(size.width, size.height))


### PR DESCRIPTION
Merge commit 436a5ae (current master) added the nil-image guard from #76 onto the newer raw-pointer macOS backend (`type Id = *mut Object`), leaving three lexical `nil` references with no import or definition. Every macOS build of master currently fails with:

```text
error[E0425]: cannot find value `nil` in this scope
  --> src/platform/macos/mod.rs:152:21
error[E0425]: cannot find value `nil` in this scope
  --> src/platform/macos/mod.rs:355:21
error[E0425]: cannot find value `nil` in this scope
  --> src/platform/macos/mod.rs:356:21
```

Reproduces from a clean `cargo check` with a git dependency pinned to master.

This PR replaces the three references with their raw-pointer equivalents — `image.is_null()` for both guards and `std::ptr::null_mut()` for the early return — preserving the guard's intent with no behavior change. `cargo check` passes on macOS after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)