### PR TITLE
fix(zbus): Update `set_volume` in `PlayerInterface` to update internal volume

### DIFF
--- a/src/platform/mpris/zbus.rs
+++ b/src/platform/mpris/zbus.rs
@@ -322,7 +322,8 @@ impl PlayerInterface {
     }
 
     #[zbus(property)]
-    fn set_volume(&self, volume: f64) {
+    fn set_volume(&mut self, volume: f64) {
+        self.state.volume = volume;
         self.send_event(MediaControlEvent::SetVolume(volume));
     }
 


### PR DESCRIPTION
The zbus `Volume` property was not updated when handling `SetVolume`, causing subsequent volume reads to return a stale value.

Update the property value in the setter before emitting `MediaControlEvent::SetVolume`.

closes #80 