### PR TITLE
mpris: add xesam:url to metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub struct MediaMetadata<'a> {
     /// For MacOS, you can look into [these lines](https://github.com/Sinono3/souvlaki/blob/384539fe83e8bf5c966192ba28e9405e3253619b/src/platform/macos/mod.rs#L131-L137) of the implementation. These lines refer to creating an [MPMediaItemArtwork](https://developer.apple.com/documentation/mediaplayer/mpmediaitemartwork) object.
     pub cover_url: Option<&'a str>,
     pub duration: Option<Duration>,
+    pub media_url: Option<&'a str>,
 }
 
 /// Events sent by the OS media controls.

--- a/src/platform/mpris/dbus/controls.rs
+++ b/src/platform/mpris/dbus/controls.rs
@@ -68,6 +68,7 @@ pub fn create_metadata_dict(metadata: &OwnedMetadata) -> HashMap<String, Variant
         artist,
         cover_url,
         duration,
+        media_url,
     } = metadata;
 
     // TODO: this is just a workaround to enable SetPosition.
@@ -93,6 +94,9 @@ pub fn create_metadata_dict(metadata: &OwnedMetadata) -> HashMap<String, Variant
     if let Some(album) = album {
         insert("xesam:album", Box::new(album.clone()));
     }
+    if let Some(url) = media_url {
+        insert("xesam:url", Box::new(url.clone()));
+    }
 
     dict
 }
@@ -104,6 +108,7 @@ pub struct OwnedMetadata {
     pub artist: Option<String>,
     pub cover_url: Option<String>,
     pub duration: Option<i64>,
+    pub media_url: Option<String>,
 }
 
 impl From<MediaMetadata<'_>> for OwnedMetadata {
@@ -115,6 +120,7 @@ impl From<MediaMetadata<'_>> for OwnedMetadata {
             cover_url: other.cover_url.map(|s| s.to_string()),
             // TODO: This should probably not have an unwrap
             duration: other.duration.map(|d| d.as_micros().try_into().unwrap()),
+            media_url: other.media_url.map(|s| s.to_string()),
         }
     }
 }


### PR DESCRIPTION
Added the missing [xesam:url](https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#xesam:url) field to MPRIS metadata